### PR TITLE
Add GitHub Actions workflow for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release
+
+# This GitHub action creates a release when a tag that matches the pattern
+# "v*" (e.g. v0.1.0) is created.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+# Releases need permissions to read and write the repository contents.
+# GitHub considers creating releases and uploading assets as writing contents.
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        with:
+          args: release --clean
+        env:
+          # GitHub sets the GITHUB_TOKEN secret automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/aicommit
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,54 @@
+version: 2
+builds:
+  - main: "./cmd/aicommit"
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.Version={{.Version}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: windows
+        goarch: "arm"
+    binary: "{{ .ProjectName }}"
+nfpms:
+  - vendor: Coder Technologies Inc.
+    homepage: https://coder.com/
+    maintainer: Ammar Bandukwala <ammar@coder.com>
+    description: |-
+      aicommit is a small command line tool for generating commit messages
+    license: CC0-1.0
+    contents:
+      - src: LICENSE
+        dst: "/usr/share/doc/{{ .ProjectName }}/copyright"
+    formats:
+      - apk
+      - deb
+archives:
+  - id: "zip"
+    format: zip
+  - id: "tarball"
+    format: tar.gz
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+
+# release:
+#   draft: true
+changelog:
+  use: github-native


### PR DESCRIPTION
- Create `.github/workflows/release.yaml` for GitHub Actions.
- Add `.goreleaser.yml` configuration for GoReleaser.
- Enable automatic releases on tagging with pattern `v*`.
- Configure multi-platform builds and archives.