### PR TITLE
feat: add commit message linter

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -2,7 +2,7 @@ This style guide is used chiefly to test that aicommit follows the
 style guide.
 
 * Only provide a multi-line message when the change is non-trivial.
-* For example, a few lines changed is trivial. Prefer a single-line message.
-* Most changes under 100 lines changed are trivial and only need a single-line
-  message.
-* Never begin the commit with an emoji
+* For example, a few lines change is trivial. Prefer a single-line message.
+* Most changes under 100 lines changed are trivial and only need a single-line message.
+* Never begin the commit with an emoji.
+* Mind standard Conventional Commits v1.0.0 using most appropriate type.

--- a/cmd/aicommit/lint.go
+++ b/cmd/aicommit/lint.go
@@ -89,7 +89,7 @@ func lint(inv *serpent.Invocation, opts runOptions) error {
 	}
 
 	if validationFailed {
-		return fmt.Fprint(inv.Stderr, "validation failed\n")
+		return fmt.Errorf("validation failed")
 	}
 	return nil
 }

--- a/cmd/aicommit/lint.go
+++ b/cmd/aicommit/lint.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -63,7 +64,7 @@ func lint(inv *serpent.Invocation, opts runOptions) error {
 	for {
 		resp, err := stream.Recv()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				debugf("stream EOF")
 				break
 			}
@@ -88,7 +89,7 @@ func lint(inv *serpent.Invocation, opts runOptions) error {
 	}
 
 	if validationFailed {
-		return fmt.Errorf("validation failed")
+		return fmt.Fprint(inv.Stderr, "validation failed\n")
 	}
 	return nil
 }

--- a/cmd/aicommit/lint.go
+++ b/cmd/aicommit/lint.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/coder/aicommit"
+	"github.com/coder/serpent"
+	"github.com/sashabaranov/go-openai"
+)
+
+func lint(inv *serpent.Invocation, opts runOptions) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Build linting prompt considering role, style guide, commit message
+	msgs, err := aicommit.BuildLintPrompt(inv.Stdout, workdir, opts.lint)
+	if err != nil {
+		return err
+	}
+	if len(opts.context) > 0 {
+		msgs = append(msgs, openai.ChatCompletionMessage{
+			Role: openai.ChatMessageRoleSystem,
+			Content: "The user has provided additional context that MUST be" +
+				" included in the commit message",
+		})
+		for _, context := range opts.context {
+			msgs = append(msgs, openai.ChatCompletionMessage{
+				Role:    openai.ChatMessageRoleUser,
+				Content: context,
+			})
+		}
+	}
+
+	ctx := inv.Context()
+	if debugMode {
+		for _, msg := range msgs {
+			debugf("%s (%v tokens)\n%s\n", msg.Role, aicommit.CountTokens(msg), msg.Content)
+		}
+	}
+
+	// Stream AI response
+	stream, err := opts.client.CreateChatCompletionStream(ctx, openai.ChatCompletionRequest{
+		Model:       opts.model,
+		Stream:      true,
+		Temperature: 0,
+		StreamOptions: &openai.StreamOptions{
+			IncludeUsage: true,
+		},
+		Messages: msgs,
+	})
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				debugf("stream EOF")
+				break
+			}
+			return err
+		}
+
+		if len(resp.Choices) > 0 {
+			inv.Stdout.Write([]byte(resp.Choices[0].Delta.Content))
+		} else {
+			inv.Stdout.Write([]byte("\n"))
+		}
+
+		// Usage is only sent in the last message.
+		if resp.Usage != nil {
+			debugf("total tokens: %d", resp.Usage.TotalTokens)
+		}
+	}
+	return nil
+}

--- a/cmd/aicommit/main.go
+++ b/cmd/aicommit/main.go
@@ -199,6 +199,7 @@ type runOptions struct {
 	dryRun        bool
 	amend         bool
 	ref           string
+	lint          string
 	context       []string
 }
 
@@ -261,6 +262,11 @@ func main() {
 			if len(inv.Args) > 0 {
 				opts.ref = inv.Args[0]
 			}
+
+			if opts.lint != "" {
+				return lint(inv, opts)
+			}
+
 			return run(inv, opts)
 		},
 		Options: []serpent.Option{
@@ -307,6 +313,12 @@ func main() {
 				FlagShorthand: "a",
 				Description:   "Amend the last commit.",
 				Value:         serpent.BoolOf(&opts.amend),
+			},
+			{
+				Name:        "lint",
+				Description: "Lint the commit message.",
+				Flag:        "lint",
+				Value:       serpent.StringOf(&opts.lint),
 			},
 			{
 				Name:          "context",

--- a/prompt.go
+++ b/prompt.go
@@ -312,7 +312,7 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 				"❌ This is rule 1.",
 				"✅ This is rule 2.",
 				"✅ This is rule 3.",
-				"🤫 This is rule 3.",
+				"🤫 This is rule 4.",
 				"",
 				"suggestion: chore: write better commit message",
 			}, "\n"),

--- a/prompt.go
+++ b/prompt.go
@@ -282,22 +282,26 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 		{
 			Role: openai.ChatMessageRoleSystem,
 			Content: strings.Join([]string{
-				"You are a tool called `aicommit` that lints commit messages according to the linting rules, and generate a linting report.",
-				"For the given commit message, lint it following to the style guide rules, and output a report following the printing rules.",
-				"Only if the report is negative, include a suggestion of valid, corrected commit message.",
-				"Only generate the report, do not include any additional text.",
+				"You are `aicommit`, a tool designed to lint commit messages and generate a detailed linting report.",
+				"You are operating in pull request (PR) title linting mode.",
+				"In this mode, linting rules for commit subjects, bodies, or bullet points are not applicable.",
+				"You do not have access to repository history or code changes and must only evaluate the given PR title.",
+				"Follow the provided linting rules strictly without making assumptions beyond the explicit rules.",
+				"Generate a report based on the style guide rules and output it according to the specified format.",
+				"If the report violates rules, include a single suggestion for a corrected PR title, otherwise skip suggestion.",
+				"Only generate the report and suggestion; do not add any additional text or context.",
 			}, "\n"),
 		},
 		// Describe printing rules
 		{
 			Role: openai.ChatMessageRoleSystem,
 			Content: strings.Join([]string{
-				"Here are report printing rules:",
-				"* every linting rule is included in the report in a separate line",
-				"* every line is prefixed with ✅ if the linting rule is satisfied, otherwise ❌ is prepended",
-				"* linting rules can't be skipped",
-				"* linting rules are plain text, not wrapped in code tags",
-				"* suggestion is a corrected commit message, written plain text, not wrapped in code tags",
+				"Report printing rules:",
+				"* Each linting rule must appear on a separate line in the report.",
+				"* Prefix lines with: ✅ for satisfied rules, ❌ for violated rules, or 🤫 for non-applicable rules.",
+				"* Non-applicable rules are those irrelevant to PR titles.",
+				"* Do not skip any linting rules in the report.",
+				"* The suggestion must be a plain text corrected PR title, prefixed with 'suggestion:', and not wrapped in code tags.",
 			}, "\n"),
 		},
 		// Provide a sample report
@@ -308,6 +312,7 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 				"❌ This is rule 1.",
 				"✅ This is rule 2.",
 				"✅ This is rule 3.",
+				"🤫 This is rule 3.",
 				"",
 				"suggestion: chore: write better commit message",
 			}, "\n"),
@@ -322,7 +327,9 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 	resp = append(resp, openai.ChatCompletionMessage{
 		Role: openai.ChatMessageRoleSystem,
 		Content: strings.Join([]string{
-			"Here are the linting rules specified in the repository style guide:",
+			"Linting rules apply when generating commit tiles based on changes and repository history, but right now you are operating as a pull request title linter",
+			"and don't have access to that information. Don't make assumptions outside of what is explicitly stated in the rules.",
+			"Here are the linting rules specified in the repository style guide.",
 			styleGuide,
 		}, "\n"),
 	})

--- a/prompt.go
+++ b/prompt.go
@@ -294,7 +294,7 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 			Content: strings.Join([]string{
 				"Here are report printing rules:",
 				"* every linting rule is included in the report in a separate line",
-				"* every line is prefixed with OK if the linting rule is satisfied, otherwise X is prepended",
+				"* every line is prefixed with ✅ if the linting rule is satisfied, otherwise ❌ is prepended",
 				"* linting rules can't be skipped",
 				"* linting rules are plain text, not wrapped in code tags",
 				"* suggestion is a corrected commit message, written plain text, not wrapped in code tags",
@@ -305,9 +305,9 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 			Role: openai.ChatMessageRoleSystem,
 			Content: strings.Join([]string{
 				"Here is a sample of negative linting report:",
-				"X This is rule 1.",
-				"OK This is rule 2.",
-				"OK This is rule 3.",
+				"❌ This is rule 1.",
+				"✅ This is rule 2.",
+				"✅ This is rule 3.",
 				"",
 				"suggestion: chore: write better commit message",
 			}, "\n"),

--- a/prompt.go
+++ b/prompt.go
@@ -152,16 +152,6 @@ func BuildPrompt(
 		},
 	}
 
-	gitRoot, err := findGitRoot(dir)
-	if err != nil {
-		return nil, fmt.Errorf("find git root: %w", err)
-	}
-
-	repo, err := git.PlainOpen(gitRoot)
-	if err != nil {
-		return nil, fmt.Errorf("open repo %q: %w", dir, err)
-	}
-
 	var buf bytes.Buffer
 	// Get the working directory diff
 	if err := generateDiff(&buf, dir, commitHash, amend); err != nil {
@@ -182,10 +172,11 @@ func BuildPrompt(
 
 	targetDiffString := buf.String()
 
-	// Get the HEAD reference
-	head, err := repo.Head()
+	commitMsgs, err := commitMessages(dir, commitHash)
 	if err != nil {
-		// No commits yet
+		return nil, fmt.Errorf("can't read commit messages: %w", err)
+	}
+	if len(commitMsgs) == 0 {
 		fmt.Fprintln(log, "no commits yet")
 		resp = append(resp, openai.ChatCompletionMessage{
 			Role:    openai.ChatMessageRoleUser,
@@ -194,46 +185,6 @@ func BuildPrompt(
 		return resp, nil
 	}
 
-	// Create a log options struct
-	logOptions := &git.LogOptions{
-		From:  head.Hash(),
-		Order: git.LogOrderCommitterTime,
-	}
-
-	// Get the commit iterator
-	commitIter, err := repo.Log(logOptions)
-	if err != nil {
-		return nil, fmt.Errorf("get commit iterator: %w", err)
-	}
-	defer commitIter.Close()
-
-	// Collect the last N commits
-	var commits []*object.Commit
-	for i := 0; i < 300; i++ {
-		commit, err := commitIter.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("iterate commits: %w", err)
-		}
-		// Ignore if commit equals ref, because we are trying to recalculate
-		// that particular commit's message.
-		if commit.Hash.String() == commitHash {
-			continue
-		}
-		commits = append(commits, commit)
-
-	}
-
-	// We want to reverse the commits so that the most recent commit is the
-	// last or "most recent" in the chat.
-	reverseSlice(commits)
-
-	var commitMsgs []string
-	for _, commit := range commits {
-		commitMsgs = append(commitMsgs, Ellipse(commit.Message, 1000))
-	}
 	// We provide the commit messages in case the actual commit diffs are cut
 	// off due to token limits.
 	resp = append(resp, openai.ChatCompletionMessage{
@@ -327,7 +278,23 @@ func BuildLintPrompt(log io.Writer, dir, commitMessage string) ([]openai.ChatCom
 	})
 
 	// Previous commit messages
-	// TODO
+	commitMsgs, err := commitMessages(dir, "")
+	if err != nil {
+		return nil, fmt.Errorf("can't read commit messages: %w", err)
+	}
+	if len(commitMsgs) == 0 {
+		resp = append(resp, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleUser,
+			Content: "No commits in the repository yet.",
+		})
+	} else {
+		resp = append(resp, openai.ChatCompletionMessage{
+			Role: openai.ChatMessageRoleSystem,
+			Content: "Here are recent commit messages in the same repository:\n" +
+				mustJSON(commitMsgs),
+		},
+		)
+	}
 
 	// Provide commit message to lint
 	resp = append(resp, openai.ChatCompletionMessage{
@@ -352,6 +319,65 @@ func readStyleGuide(dir string) (string, error) {
 		return styleGuide, nil
 	}
 	return defaultUserStyleGuide, nil
+}
+
+func commitMessages(dir string, commitHash string) ([]string, error) {
+	gitRoot, err := findGitRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("find Git root: %w", err)
+	}
+
+	repo, err := git.PlainOpen(gitRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open repository %q: %w", dir, err)
+	}
+
+	// Get the HEAD reference
+	head, err := repo.Head()
+	if err != nil {
+		return nil, nil // no commits yet
+	}
+
+	// Create a log options struct
+	logOptions := &git.LogOptions{
+		From:  head.Hash(),
+		Order: git.LogOrderCommitterTime,
+	}
+
+	// Get the commit iterator
+	commitIter, err := repo.Log(logOptions)
+	if err != nil {
+		return nil, fmt.Errorf("get commit iterator: %w", err)
+	}
+	defer commitIter.Close()
+
+	// Collect the last N commits
+	var commits []*object.Commit
+	for i := 0; i < 300; i++ {
+		commit, err := commitIter.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("iterate commits: %w", err)
+		}
+		// Ignore if commit equals ref, because we are trying to recalculate
+		// that particular commit's message.
+		if commitHash != "" && commit.Hash.String() == commitHash {
+			continue
+		}
+		commits = append(commits, commit)
+	}
+
+	// We want to reverse the commits so that the most recent commit is the
+	// last or "most recent" in the chat.
+	reverseSlice(commits)
+
+	var msgs []string
+	for _, commit := range commits {
+		msgs = append(msgs, Ellipse(commit.Message, 1000))
+	}
+	return msgs, nil
 }
 
 // generateDiff uses the git CLI to generate a diff for the given reference.


### PR DESCRIPTION
Fixes: https://github.com/coder/aicommit/issues/11

_For reviewers: If you want to play with the tool you need to setup OpenAI key, and if you need one please let me know._

This PR introduces a commit message (or PR titles) linter according to repository style guide.

The biggest challenge is ensuring that the results are consistent. AI often draws incorrect conclusions and tends to struggle with maintaining precise line lengths. We might need to revise our COMMITS.md guidelines: instead of saying _limit line length to 50 characters_, we could try _keep commit messages concise_.

In a follow-up PR, we can introduce a custom output format, e.g. JSON struct.

```
make build
cd ../coder
../aicommit/bin/aicommit --lint "fix: make GetWorkspacesEligibleForTransition return even less false positives"

../aicommit/bin/aicommit --lint "fix: make GetWorkspacesEligibleForTransition return even less false positives"
❌ Limit the subject line to 50 characters.
✅ Use the imperative mood in the subject line.
✅ Capitalize the subject line such as "Fix Issue 886" and don't end it with a period.
✅ The subject line should summarize the main change concisely.
✅ Only include a body if absolutely necessary for complex changes.
✅ If a body is needed, separate it from the subject with a blank line.
✅ Wrap the body at 72 characters.
✅ In the body, explain the why, not the what (the diff shows the what).
✅ Use bullet points in the body only for truly distinct changes.
✅ Be extremely concise. Assume the reader can understand the diff.
✅ Never repeat information between the subject and body.
✅ Do not repeat commit messages from previous commits.
✅ Prioritize clarity and brevity over completeness.
✅ Adhere to the repository's commit style if it exists.

suggestion: fix: reduce false positives in GetWorkspacesEligibleForTransition
```

Troubleshooting:

```
export AICOMMIT_DEBUG=true # see prompt and tokens
```